### PR TITLE
docker: changed db mount path, fixes #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ The app will be available at http://localhost:2244.
 
 Database is saved under `db` folder. This folder is mounted in `app` container to persist data changes on host disk.
 
-For development purpose, you can use both `docker-compose.yml` and `docker-compose-dev.yml` which allows you to work on copanier source code and make gunicorn automatically reload workers when code changes.
+For development purpose, you can use both `docker-compose.yml` and `docker-compose-dev.yml` which allows you to work on copanier source code and make gunicorn automatically reload workers when code changes:
+
+```bash
+sudo docker-compose -p copanier -f docker-compose.yml -f docker-compose-dev.yml up
+```
 
 ## Run local server
 

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.3"
 services:
   app:
     command: /srv/copanier-venv/bin/gunicorn -k roll.worker.Worker copanier:app --bind 0.0.0.0:2244 --reload --log-level debug --access-logfile - --error-logfile -

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.3"
 services:
   app:
     build:
@@ -6,7 +6,7 @@ services:
       dockerfile: "./docker/Dockerfile"
     command: /srv/copanier-venv/bin/gunicorn -k roll.worker.Worker copanier:app --bind 0.0.0.0:2244
     volumes:
-      - "../copanier/db:/srv/copanier/db" # To persist database changes
+      - "../db:/srv/copanier/db" # To persist database changes
     restart: always
   static:
     image: "nginx:latest"


### PR DESCRIPTION
Il y avait une erreur dans le chemin de montage du dossier contenant la base de données, ce qui a provoqué le problème reporté dans l'issue #65 .