### PR TITLE
Affichage des infos sup. produit par défaut

### DIFF
--- a/copanier/static/page.css
+++ b/copanier/static/page.css
@@ -28,4 +28,7 @@
     footer {
       display: none;
     }
+    .infos-hidden {
+      display: block;
+    }
 }


### PR DESCRIPTION
Ajout du css au media print pour afficher par défaut les infos produit pour l’impression.