### PR TITLE
Ajout css pour la fonctionnalité ‘Plus d'infos’

### DIFF
--- a/copanier/static/app.css
+++ b/copanier/static/app.css
@@ -829,3 +829,17 @@ footer {
 }
 
 .big-button { margin: 2em;}
+
+/* Bouton plus d'infos */
+
+.moreinfos {
+  cursor: pointer;
+}
+
+.infos-hidden {
+  display: none;
+}
+
+.moreinfos:focus+.infos-hidden {
+  display: block;
+}


### PR DESCRIPTION
Ajout d’une fonctionnalité basique en css d’affichage au clic des infos supplémentaires de produit via le bouton ‘Plus d’infos’. Un clic sur un autre bouton similaire dans la page cache automatiquement le contenu du précédent.

