### PR TITLE
Specify the version in copanier/__init__.py.

### DIFF
--- a/copanier/__init__.py
+++ b/copanier/__init__.py
@@ -5,6 +5,7 @@ from roll.extensions import simple_server, static
 from .models import Product, Person, Order, Delivery
 from .views.core import app
 
+__version__ = "0.0.5"
 
 @minicli.cli()
 def shell():

--- a/copanier/templates/base.html
+++ b/copanier/templates/base.html
@@ -1,13 +1,13 @@
-
 {% import "includes/macros.html" as macros %}
 
 <!DOCTYPE html>
 <html>
+
 <head>
-	<title>{% if title %}{{ title }} - {% endif %}{{ config.SITE_NAME }}</title>
+    <title>{% if title %}{{ title }} - {% endif %}{{ config.SITE_NAME }}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('/static/app.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('/static/app.css') }}?v={{ version }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('/static/icomoon.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('/static/purecss.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('/static/side-menu.css') }}">
@@ -18,11 +18,13 @@
     {% endblock head %}
 
 </head>
+
 <body>
     {% if config.DEMO_MODE %}
     <div class="header">
         <div class="home-menu pure-menu pure-menu-horizontal pure-menu-fixed demo-mode">
-            <p class="pure-menu-heading">Le site est en mode démo. <a href="{{ url_for('desactivate_demo') }}">désactiver</a></p>
+            <p class="pure-menu-heading">Le site est en mode démo. <a
+                    href="{{ url_for('desactivate_demo') }}">désactiver</a></p>
         </div>
     </div>
     {% endif %}
@@ -35,23 +37,27 @@
         <div id="menu">
             <div class="pure-menu">
                 <h1 id="sitename"><a href="{{ url_for('home') }}">{{ config.SITE_NAME }}</a></h1>
-								{% block additional_menu %}{% endblock %}
+                {% block additional_menu %}{% endblock %}
                 <ul class="pure-menu-list">
                     <li class="pure-menu-item">
-                        <a class="pure-menu-link" href="{{ url_for('archives') }}"><i class="icon-happy"></i>&nbsp;Voir les archives</a>
+                        <a class="pure-menu-link" href="{{ url_for('archives') }}"><i class="icon-happy"></i>&nbsp;Voir
+                            les archives</a>
                     </li>
                     {% if request.user and request.user.is_staff %}
                     <li class="pure-menu-item">
-                        <a class="pure-menu-link" href="{{ url_for('new_delivery') }}"><i class="icon-hotairballoon"></i>&nbsp;Nouvelle distribution</a>
+                        <a class="pure-menu-link" href="{{ url_for('new_delivery') }}"><i
+                                class="icon-hotairballoon"></i>&nbsp;Nouvelle distribution</a>
                     </li>
                     {% endif %}
                     {% if request.user and (request.user.is_staff or not config.HIDE_GROUPS_LINK) %}
                     <li class="pure-menu-item">
-                        <a class="pure-menu-link" class="pure-menu-link" href="{{ url_for('groups') }}"><i class="icon-globe"></i>&nbsp;Gérer les groupes</a>
+                        <a class="pure-menu-link" class="pure-menu-link" href="{{ url_for('groups') }}"><i
+                                class="icon-globe"></i>&nbsp;Gérer les groupes</a>
                     </li>
                     {% endif %}
                     <li class="pure-menu-item">
-                        <a class="pure-menu-link" href="{{ url_for('logout') }}"><i class="icon-lock"></i>&nbsp;Se déconnecter</a>
+                        <a class="pure-menu-link" href="{{ url_for('logout') }}"><i class="icon-lock"></i>&nbsp;Se
+                            déconnecter</a>
                     </li>
                 </ul>
             </div>
@@ -60,7 +66,7 @@
         <h1 id="sitename">{{ config.SITE_NAME }}</h1>
         {% endif %}
         <div class="toplink">
-        {% block toplink %}{% endblock %}
+            {% block toplink %}{% endblock %}
         </div>
         <div id="main">
             <div class="content {% block is_wide %}narrow{% endblock %}">
@@ -68,30 +74,32 @@
                 {% endblock body %}
             </div>
         </div>
-        <footer>Copanier est un logiciel libre. <a href="https://github.com/spiral-project/copanier">Vous pouvez y contribuer et l'améliorer ! ❤️</a></footer>
+        <footer>Copanier est un logiciel libre. <a href="https://github.com/spiral-project/copanier">Vous pouvez y
+                contribuer et l'améliorer ! ❤️</a></footer>
     </div>
 
 
     <script src="{{ url_for('/static/js/flash.min.js') }}"></script>
     <script src="{{ url_for('/static/js/app.js') }}"></script>
-		<script src="{{ url_for('/static/js/menus.js') }}"></script>
-		<script>
-    {% if message %}
-    new window.FlashMessage("{{ message[0] }}", "{{ message[1] }}", {
-        progress: true,
-        interactive: true,
-        timeout: 8000,
-        theme: "dark"
-    });
-		{% endif %}
+    <script src="{{ url_for('/static/js/menus.js') }}"></script>
+    <script>
+        {% if message %}
+        new window.FlashMessage("{{ message[0] }}", "{{ message[1] }}", {
+            progress: true,
+            interactive: true,
+            timeout: 8000,
+            theme: "dark"
+        });
+        {% endif %}
 
-		// Disable scrolling on inputs, as it make users do weird things.
-		// Taken from https://stackoverflow.com/a/38589039/147077
-		document.addEventListener("wheel", function(event){
-		    if(document.activeElement.type === "number"){
-		        document.activeElement.blur();
-		    }
-		});
+        // Disable scrolling on inputs, as it make users do weird things.
+        // Taken from https://stackoverflow.com/a/38589039/147077
+        document.addEventListener("wheel", function (event) {
+            if (document.activeElement.type === "number") {
+                document.activeElement.blur();
+            }
+        });
     </script>
 </body>
+
 </html>

--- a/copanier/views/core.py
+++ b/copanier/views/core.py
@@ -20,6 +20,8 @@ class Response(RollResponse):
         context["config"] = config
         context["request"] = self.request
         context["url_for"] = app.url_for
+        from .. import __version__
+        context["version"] = __version__
         if self.request.cookies.get("message"):
             try:
                 message = json.loads(self.request.cookies["message"])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = copanier
-version = 0.0.4
+version-from-file = copanier/__init__.py
 
 [options]
 packages = find:


### PR DESCRIPTION
And use it when loading the css files in order to not have the css files cached by the browsers after an update.

Fix #124

cc @Gwenael-F 