### PR TITLE
Fixes on dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster
 EXPOSE 2244
 ENV DEBIAN_FRONTEND=noninteractive 
 RUN apt-get -y update
-RUN apt-get -y install git python3-dev python3-venv python3-pip libcairo-dev libpango1.0-dev locales
+RUN apt-get -y install git python3-dev python3-venv python3-pip libcairo-dev libpango1.0-dev libjpeg-dev locales
 
 RUN sed -i -e 's/# fr_FR.UTF-8 UTF-8/fr_FR.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     debts==0.5
     emails==0.6
     Weasyprint==51
+    MarkupSafe==2.0.1
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Hello,
i was trying copanier! the docker build was broken for me, i got a couple of errors:
- Pillow (required by weasyprint) looking for libjpeg-dev (i added it to Dockerfile)
- Jinja broken by MarkupSafe >= 2.1.0 (i pinned it to 2.0.1, probably a better fix is to update jinja)

Ciao!