### PR TITLE
Docker version: Building from Debian bullseye, not so old as buster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye-slim
 
 EXPOSE 2244
 ENV DEBIAN_FRONTEND=noninteractive 


### PR DESCRIPTION
The Dockerfile is based on Debian:bullseye instead of buster